### PR TITLE
chore: remove distribution files from github release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -15,12 +15,6 @@
       "assets": ["docs", "yarn.lock"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
-    ["@semantic-release/github", {
-        "assets": [
-            {"path": "es", "label": "ES Modules Distribution"},
-            {"path": "lib", "label": "CJS Distribution"},
-            {"path": "docs/CHANGELOG.md", "label": "Changelog"},
-        ]
-    }]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
1. Removed distribution files from github release
2. Removed changelog file from github release

## Description

<!--- Describe your changes in detail -->
Having distribution files in the github release is an overkill since it can be accessed from npm.
Having the changelog there also doesn't make sense since the release's body contains the release notes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](../docs/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
