### PR TITLE
chore: cache node_modules before running any other job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,16 +6,13 @@ on:
       - master
 
 jobs:
-  lint:
-    name: Lint Branch
+  load-modules:
+    name: Load and Cache Dependencies
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --unshallow
       - name: Load Modules
-        id: cache
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -23,6 +20,22 @@ jobs:
       - name: Verify Dependencies
         run: yarn
         if: steps.cache.outputs.cache-hit != 'true'
+
+  lint:
+    name: Lint Branch
+    needs: [load-modules]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run: git fetch --unshallow
+      - name: Restore Modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Lint Code
         run: yarn lint
       - name: Lint Commit
@@ -30,36 +43,31 @@ jobs:
 
   test:
     name: Test Branch
+    needs: [load-modules]
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Load Modules
-        id: cache
+      - name: Restore Modules
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Verify Dependencies
-        run: yarn
-        if: steps.cache.outputs.cache-hit != 'true'
       - name: Test
         run: yarn test
 
   build:
     name: Build Branch
+    needs: [load-modules]
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Load Modules
+      - name: Restore Modules
         id: cache
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Verify Dependencies
-        run: yarn
-        if: steps.cache.outputs.cache-hit != 'true'
       - name: Build
         run: yarn build


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
- Add job `load-modules` to load and cache node_modules
- Add `load-modules` as a dependency of all the other jobs
- Remove dependency check for each job since it's being loaded before

## Description

<!--- Describe your changes in detail -->
Right now each job has it's own node_modules' caching and if they run all 3 at the same time they will all load and cache the modules instead of reusing them.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
With this change `node_modules` will only be downloaded once and restored thrice.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Chore (workflows / linting / tooling)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](../docs/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
