### PR TITLE
fix: ensures process is not undefined before logging to console

### DIFF
--- a/src/ResponsiveProvider/useDebugResponsive.js
+++ b/src/ResponsiveProvider/useDebugResponsive.js
@@ -2,11 +2,13 @@ import { useEffect } from 'react';
 
 const useDebugResponsive = (contextObject, currentMediaType) => {
     useEffect(() => {
-        if (
+        const isDevEnv =
             typeof process !== 'undefined' &&
+            process !== null &&
             process.env &&
-            process.env.NODE_ENV === 'development'
-        ) {
+            process.env.NODE_ENV === 'development';
+
+        if (isDevEnv) {
             /* eslint-disable no-console */
             console.group(
                 '%c @farfetch/react-context-responsive updated!',

--- a/src/ResponsiveProvider/useDebugResponsive.js
+++ b/src/ResponsiveProvider/useDebugResponsive.js
@@ -2,7 +2,11 @@ import { useEffect } from 'react';
 
 const useDebugResponsive = (contextObject, currentMediaType) => {
     useEffect(() => {
-        if (process && process.env && process.env.NODE_ENV === 'development') {
+        if (
+            typeof process !== 'undefined' &&
+            process.env &&
+            process.env.NODE_ENV === 'development'
+        ) {
             /* eslint-disable no-console */
             console.group(
                 '%c @farfetch/react-context-responsive updated!',


### PR DESCRIPTION
# PR Details

* Wraps the `process` conditional check in a `typeof` comparison to ensure `process` is not `undefined`

## Description

In some instances, the global `process` object is undefined.
If it is undefined, an app using `react-context-responsive` crashes:
> Uncaught ReferenceError: process is not defined

One example scenario where this can occur is when using webpack 5. This is because as of webpack 5:
> "...no longer include a polyfill for this Node.js variable. Avoid using it in the frontend code."

(For more info, see ["Level 5: Runtime Errors" here](https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advises))

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Farfetch/react-context-responsive/issues/56

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Without the `undefined` check, my application crashes.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by forking the project, making this change & installing via the filesystem.

Unfortunately, I can't write a unit/integration test because I can't overwrite `global.process = undefined`, because `jest`/`js-dom` crashes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Chore (workflows / linting / tooling)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](../docs/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
