### PR TITLE
feat: peer dependency support for react v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
# PR Details
Add support for react v17 as a peer dependency.

## Description
There is no issues using the library with React v17. But missing support makes updating projects difficult (have to `npm update --force`)

## Related Issue
#59 

## Motivation and Context

There is no issues using the library with React v17. But missing support makes updating projects difficult (have to `npm update --force`)

## How Has This Been Tested
Tested on two projects with react v17 with no issue so far. I run internal test with no issues.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Chore (workflows / linting / tooling)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](../docs/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
